### PR TITLE
Lowercase import titles

### DIFF
--- a/djangomodelimport/parsers.py
+++ b/djangomodelimport/parsers.py
@@ -18,26 +18,36 @@ class ImportParser:
 
 
 class TablibCSVImportParser(ImportParser):
+    def get_soft_headings(self):
+        # Soft headings are used to provide similar heading suggestions
+        # and look like this: {the field name: [list of other possible names] }
+        # eg.
+        #
+        # soft_headings = {
+        #   'type': ['Asset Type'],
+        # }
+        header_map = {}
+        if hasattr(self.modelvalidator, 'ImporterMeta'):
+            if hasattr(self.modelvalidator.ImporterMeta, 'soft_headings'):
+                importer_softheadings = self.modelvalidator.ImporterMeta.soft_headings
+
+                for renameto in importer_softheadings:  # new column name
+                    for renamefrom in importer_softheadings[renameto]:  # old column name
+                        header_map[renamefrom.lower()] = renameto.lower()
+        return header_map
+
     def parse(self, data):
         dataset = tablib.Dataset()
         dataset.csv = data
 
-        if hasattr(self.modelvalidator, 'ImporterMeta'):
-            # has additional importer config defined
-            if hasattr(self.modelvalidator.ImporterMeta, 'soft_headings'):
-                importer_softheadings = self.modelvalidator.ImporterMeta.soft_headings
+        header_map = self.get_soft_headings()
 
-                # rename headers according to a soft_headings mapping dict which renames
-                # columns to a consistent value
-                # header mapping looks like this
-                # soft_headings = {
-                #   'colnewname': ['fromname1', 'fromname2']
-                # }
-                for renameto in importer_softheadings:  # new column name
-                    for renamefrom in importer_softheadings[renameto]:  # old column name
-                        for idx, header in enumerate(dataset.headers):  # replace it in headers if found
-                            if header.strip() == renamefrom.strip():
-                                dataset.headers[idx] = renameto
+        # Make all our headings lowercase and sub in soft headings
+        for col_id, header in enumerate(dataset.headers):  # replace it in headers if found
+            header_name = header.strip().lower()
+            dataset.headers[col_id] = header_name
+            if header_name in header_map.keys():
+                dataset.headers[col_id] = header_map[header_name]
 
         return (dataset.headers, dataset.dict)
 


### PR DESCRIPTION
This lowercases all of the headings that get passed to the importer, and makes the soft names a bit easier to understand (e.g. header_map is a flat dictionary of from:to now).

This change depends on the other branch being merged first ... so merge feature/fix-required-fields-uploads and then rebase this against master.