### PR TITLE
dayfirst=False only if the value leads with 4-digit year

### DIFF
--- a/djangomodelimport/fields.py
+++ b/djangomodelimport/fields.py
@@ -82,7 +82,8 @@ class DateTimeParserField(forms.DateTimeField):
         value = (value or '').strip()
         if value:
             try:
-                return from_current_timezone(parser.parse(value, dayfirst=bool(match(r'^\d\d?.\d\d?.\d{4}$', value))))
+                dayfirst = not bool(match(r'^\d\d\d\d?.\d\d?.\d\d$', value))
+                return from_current_timezone(parser.parse(value, dayfirst=dayfirst))
             except (TypeError, ValueError, OverflowError):
                 raise forms.ValidationError(self.error_messages['invalid'], code='invalid')
 

--- a/djangomodelimport/fields.py
+++ b/djangomodelimport/fields.py
@@ -82,7 +82,7 @@ class DateTimeParserField(forms.DateTimeField):
         value = (value or '').strip()
         if value:
             try:
-                dayfirst = not bool(match(r'^\d\d\d\d?.\d\d?.\d\d$', value))
+                dayfirst = not bool(match(r'^\d{4}.\d\d?.\d\d?$', value))
                 return from_current_timezone(parser.parse(value, dayfirst=dayfirst))
             except (TypeError, ValueError, OverflowError):
                 raise forms.ValidationError(self.error_messages['invalid'], code='invalid')


### PR DESCRIPTION
If we can assume that we will always see DMY or YMD dates, this seems sensible.  Could have an argument for MDY?