### PR TITLE
Fix/partialimport flatrelatedfield

### DIFF
--- a/djangomodelimport/magic.py
+++ b/djangomodelimport/magic.py
@@ -41,7 +41,7 @@ class FlatRelatedFieldFormMixin:
                 for attr, value in mapped_values.items():
                     setattr(instance, attr, value)
 
-            instance.save()  # @todo this gets fired during preview :( this whole thing needs to go
+            instance.save()  # NOTE: This gets fired during preview, but that's ok, since we wrap previews in a big rollback transaction.
             self.data[field] = instance
 
     def get_headers(self, given_headers=None):

--- a/tests/djangoexample/testapp/tests.py
+++ b/tests/djangoexample/testapp/tests.py
@@ -128,31 +128,13 @@ class ImporterTests(TestCase):
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0], (2, [('id', ['Book 333 cannot be updated.'])]))
 
-    def test_importer_limited_queryset(self):
-        a1 = Author.objects.create(name='Author Joe')
-        a2 = Author.objects.create(name='Author Bill')
-
-        b1 = Book.objects.create(id=111, name='Hello', author=a1)
-        Book.objects.create(id=333, name='Goodbye', author=a2)
-
-        parser = TablibCSVImportParser(BookImporter)
-        headers, rows = parser.parse(sample_csv_2_books)
-
-        importer = ModelImporter(BookImporter)
-        preview = importer.process(headers, rows, allow_update=True, limit_to_queryset=Book.objects.filter(id=b1.id), commit=False)
-
-        # Make sure there's no errors
-        errors = preview.get_errors()
-        self.assertEqual(len(errors), 1)
-        self.assertEqual(errors[0], (2, [('id', ['Book 333 cannot be updated.'])]))
-
     def test_required_fields_on_update(self):
         a1 = Author.objects.create(name='Aidan Lister')
         a2 = Author.objects.create(name='Maddi T')
 
         b1 = Book.objects.create(id=801, name='Hello b1', author=a1)
-        b2 = Book.objects.create(id=802, name='Hello b2', author=a1)
-        b3 = Book.objects.create(id=803, name='Hello b3', author=a2)
+        Book.objects.create(id=802, name='Hello b2', author=a1)
+        Book.objects.create(id=803, name='Hello b3', author=a2)
         b4 = Book.objects.create(id=804, name='Hello b4', author=a2)
 
         parser = TablibCSVImportParser(BookImporter)


### PR DESCRIPTION
Fixes a bug with FlatRelatedFields getting completely ignored on updates.

Was caused by the partial update work, which erroneously popped FlatRelatedFields as part of its popping ramapage:
https://github.com/uptick/django-model-import/commit/818031e133c342addffc070924d8419507e21240#diff-465710c478dda996e097c2541134a72680f28fdcf0542f316d2cc1e1113d6e93R51-R59