### PR TITLE
Cache re-raise errors instead of returning none

### DIFF
--- a/djangomodelimport/__init__.py
+++ b/djangomodelimport/__init__.py
@@ -11,4 +11,4 @@ from .parsers import BaseImportParser, TablibCSVImportParser, TablibXLSXImportPa
 from .resultset import ImportResultRow, ImportResultSet  # noqa
 from .widgets import CompositeLookupWidget  # noqa
 
-__version__ = '0.4.13'
+__version__ = '0.4.14'

--- a/djangomodelimport/loaders.py
+++ b/djangomodelimport/loaders.py
@@ -12,7 +12,7 @@ class CachedInstanceLoader(dict):
         self.multifield = isinstance(to_field, list) or isinstance(to_field, tuple)
 
     def __getitem__(self, item):
-        # Attempted to get the currently cached value
+        # Attempt to get the currently cached value.
         value = super(CachedInstanceLoader, self).__getitem__(item)
 
         # If the cached value is an error, re-raise
@@ -30,9 +30,9 @@ class CachedInstanceLoader(dict):
         try:
             self[value] = inst = self.queryset.get(**params)
         except self.model.DoesNotExist as err:
-            self[value] = inst = err  # Further warnings will be re-raised
+            self[value] = err  # Further warnings will be re-raised
             raise
         except self.model.MultipleObjectsReturned as err:
-            self[value] = inst = err  # Further warnings will be re-raised
+            self[value] = err  # Further warnings will be re-raised
             raise
         return inst

--- a/djangomodelimport/loaders.py
+++ b/djangomodelimport/loaders.py
@@ -1,14 +1,25 @@
 class CachedInstanceLoader(dict):
-    """ A clever cache that queries the database for any missing objects.
+    """A clever cache that queries the database for any missing objects.
 
     If there's an error, it's only raised against the first item that causes it, then it's
     cached for extra speed.
     """
+
     def __init__(self, queryset, to_field, *args, **kwargs):
         self.queryset = queryset
         self.model = queryset.model
         self.to_field = to_field
         self.multifield = isinstance(to_field, list) or isinstance(to_field, tuple)
+
+    def __getitem__(self, item):
+        # Attempted to get the currently cached value
+        value = super(CachedInstanceLoader, self).__getitem__(item)
+
+        # If the cached value is an error, re-raise
+        if isinstance(value, Exception):
+            raise value
+
+        return value
 
     def __missing__(self, value):
         if self.multifield:
@@ -18,10 +29,10 @@ class CachedInstanceLoader(dict):
 
         try:
             self[value] = inst = self.queryset.get(**params)
-        except self.model.DoesNotExist:
-            self[value] = inst = None  # Further warnings will be surpressed
+        except self.model.DoesNotExist as err:
+            self[value] = inst = err  # Further warnings will be re-raised
             raise
-        except self.model.MultipleObjectsReturned:
-            self[value] = inst = None  # Further warnings will be surpressed
+        except self.model.MultipleObjectsReturned as err:
+            self[value] = inst = err  # Further warnings will be re-raised
             raise
         return inst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-model-import"
-version = "0.4.13"
+version = "0.4.14"
 description = "A Django library for importing CSVs and other structured data quickly using Django's ModelForm for validation and deserialisation into an instance."
 authors = ["Aidan Lister <aidan@uptickhq.com>"]
 readme = "README.md"


### PR DESCRIPTION
Have caches re-raise errors to prevent import failing silently when encountering a line with non-mandatory data