### PR TITLE
Feature/virtual fields & sourcefieldswitcher

### DIFF
--- a/djangomodelimport/fields.py
+++ b/djangomodelimport/fields.py
@@ -179,3 +179,11 @@ class JSONField(forms.Field):
         if value and not isinstance(value, str):
             value = json.dumps(value, sort_keys=True, indent=4)
         return super().render(name, value, attrs)
+
+
+class SourceFieldSwitcher(forms.Field):
+    fields = None
+
+    def __init__(self, *fields):
+        self.fields = fields
+        super().__init__()

--- a/djangomodelimport/formclassbuilder.py
+++ b/djangomodelimport/formclassbuilder.py
@@ -1,0 +1,90 @@
+from functools import cached_property
+
+from django.db.models.fields import NOT_PROVIDED
+from django.forms import modelform_factory
+
+from djangomodelimport.widgets import NamedSourceWidget, CompositeLookupWidget
+
+from .fields import FlatRelatedField, JSONField, SourceFieldSwitcher
+
+class FormClassBuilder:
+    """Constructs instances of ImporterModelForm, taking headers into account."""
+    def __init__(self, modelimportformclass, headers):
+        self.headers = headers
+        self.modelimportformclass = modelimportformclass
+        self.model = modelimportformclass.Meta.model
+
+    def build_update_form(self):
+        return self._get_modelimport_form_class(fields=self.valid_fields)
+
+    def build_create_form(self):
+        # Combine valid & required fields; preserving order of valid fields.
+        form_fields = self.valid_fields + list(set(self.required_fields) - set(self.valid_fields))
+        return self._get_modelimport_form_class(fields=form_fields)
+
+    @cached_property
+    def valid_fields(self):
+        """ Using the provided headers, prepare a list of valid fields for this importer.
+            Preservers field ordering as defined by the headers.
+        """
+        # 1) Determine which of the provided import headers are legitimate by comparing directly against the form fields.
+        valid_present_fields = [field for field in self.headers if field in self.modelimportformclass.base_fields]
+        # 2) Add virtual fields:
+        # - FlatRelatedField: these are a collection of other columns that build a relation on the fly. Always add.
+        # - JSONField: these are provided as FIELDNAME__SOME_DATA, so won't match directly. Just let the whole thing through.
+        # - Anything using NamedSourceWidget: these lookup columns might not match the form field.
+        # - Anything using CompositeLookupWidget: these lookup columns might not always mention the form field target.
+        # - NamedSourceWidget or CompositeLookupWidget mentioned within a SourceFieldSwitcher.
+        # - Fields defined as attributes on the importer, but not listed as form fields (eg because they're used for postprocessing).
+        header_set = set(self.headers)
+        virtual_fields = []
+        for field_name, field_class in self.modelimportformclass.base_fields.items():
+            if isinstance(field_class, FlatRelatedField | JSONField):
+                virtual_fields.append(field_name)
+            elif isinstance(field_class.widget, NamedSourceWidget):
+                if field_class.widget.source in header_set:
+                    virtual_fields.append(field_name)
+            elif isinstance(field_class.widget, CompositeLookupWidget):
+                if set(field_class.widget.source) < header_set:
+                    virtual_fields.append(field_name)
+            elif isinstance(field_class, SourceFieldSwitcher):
+                for switch_field_class in field_class.fields:
+                    if isinstance(switch_field_class.widget, NamedSourceWidget):
+                        if switch_field_class.widget.source in header_set:
+                            virtual_fields.append(field_name)
+                    elif isinstance(field_class.widget, CompositeLookupWidget):
+                        if set(field_class.widget.source) < header_set:
+                            virtual_fields.append(field_name)
+
+        return valid_present_fields + list(set(virtual_fields) - set(valid_present_fields))
+
+    @cached_property
+    def required_fields(self):
+        fields = self.model._meta.get_fields()
+        required_fields = []
+
+        # Required means `blank` is False and `editable` is True.
+        for f in fields:
+            # Note - if the field doesn't have a `blank` attribute it is probably
+            # a ManyToOne relation (reverse foreign key), which you probably want to ignore.
+            if getattr(f, 'blank', True) is False and getattr(f, 'editable', True) is True and f.default is NOT_PROVIDED:
+                required_fields.append(f.name)
+        return required_fields
+
+    def _get_modelimport_form_class(self, fields):
+        """ Return a modelform for use with this data.
+
+        We use a modelform_factory to dynamically limit the fields on the import,
+        otherwise the absence of a value can be taken as false for boolean fields,
+        where as we want the model's default value to kick in.
+        """
+        klass = modelform_factory(
+            self.model,
+            form=self.modelimportformclass,
+            fields=fields,
+        )
+        # Remove fields altogether if they haven't been specified in the import (makes sense for updates). #houseofcards..
+        base_fields_to_del = set(klass.base_fields.keys()) - set(fields)
+        for f in base_fields_to_del:
+            del klass.base_fields[f]
+        return klass

--- a/djangomodelimport/forms.py
+++ b/djangomodelimport/forms.py
@@ -3,10 +3,16 @@ from collections import defaultdict
 from django import forms
 from django.core.exceptions import NON_FIELD_ERRORS
 
-from .magic import CachedChoiceFieldFormMixin, FlatRelatedFieldFormMixin, JSONFieldFormMixin
+from .magic import CachedChoiceFieldFormMixin, FlatRelatedFieldFormMixin, JSONFieldFormMixin, SourceFieldSwitcherMixin
 
 
-class ImporterModelForm(JSONFieldFormMixin, FlatRelatedFieldFormMixin, CachedChoiceFieldFormMixin, forms.ModelForm):
+class ImporterModelForm(
+    SourceFieldSwitcherMixin,
+    JSONFieldFormMixin,
+    FlatRelatedFieldFormMixin,
+    CachedChoiceFieldFormMixin,
+    forms.ModelForm
+):
     """ Extends the ModelForm to prime our caches and tweaks the validation
     routines to ensure we are not doing too many queries with our cached fields.
     """

--- a/djangomodelimport/widgets.py
+++ b/djangomodelimport/widgets.py
@@ -48,6 +48,18 @@ class CompositeLookupWidget(forms.Widget):
                 return True
         return False
 
+class NamedSourceWidget(forms.Widget):
+    """This lets you override the column from which to import data."""
+
+    def __init__(self, source, *args, **kwargs):
+        self.source = source
+        super().__init__(*args, **kwargs)
+
+    def value_from_datadict(self, data, files, name):
+        return data.get(self.source, "")
+
+    def value_omitted_from_data(self, data, files, name):
+        return self.source not in data
 
 class JSONFieldWidget(forms.Widget):
     template_name = 'django/forms/widgets/textarea.html'

--- a/tests/djangoexample/testapp/importers.py
+++ b/tests/djangoexample/testapp/importers.py
@@ -41,9 +41,6 @@ class CitationImporter(djangomodelimport.ImporterModelForm):
             'author',
             'metadata',
         )
-        # We need to tell django-model-import to import data into "metadata"
-        # even if it's not in the table headings, because it will look like metadata_xxx, metadata_yyy
-        virtual_fields = ('metadata', )
 
 
 class CompanyImporter(djangomodelimport.ImporterModelForm):


### PR DESCRIPTION
1) Introduces SourceFieldSwitcher, a pseudo-field for allowing a variety of different columns to map to the same destination.
This is super useful for FKs, which you might want to look up by, say, `name` or `ref`.

2) Tidies up a lot of the form class creation code into a separate `formclassbuilder` file.

3) Drops the need for defining "virtual_fields". This was a lazy way of telling DMI that a field was to be present on the form despite not coming explicitly from the import file. FlatRelatedField was already being handled automatically, however JSONField and anything using CompositeLookupWidgets wasn't. Moving forward, all these fields will just work properly without needing to define stuff in "virtual_fields".