### PR TITLE
Rework ImportModelClass to provide available headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ examples/example_site/env
 **.pem
 src/
 .idea/
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ environ/
 examples/example_site/env
 **.pem
 src/
+.idea/
+.vscode

--- a/djangomodelimport/core.py
+++ b/djangomodelimport/core.py
@@ -91,6 +91,12 @@ class ModelImporter:
             to_be_skipped = skip_func(row) if skip_func else False
             import_form_class = ModelCreateForm if to_be_created else ModelUpdateForm
 
+            # Evaluate skip first
+            # So that the import doesn't die for no reason
+            if to_be_skipped:
+                skipped += 1
+                continue
+
             if to_be_created and not allow_insert:
                 errors = [("id", ["Creating new rows is not permitted"])]
                 importresult.append(i, row, errors, instance, to_be_created)
@@ -122,10 +128,6 @@ class ModelImporter:
                             ],
                         )
                     ]
-
-            if to_be_skipped:
-                skipped += 1
-                continue
 
             if not errors:
                 form = import_form_class(

--- a/djangomodelimport/core.py
+++ b/djangomodelimport/core.py
@@ -8,7 +8,7 @@ from .resultset import ImportResultSet
 class ModelImporter:
     """A base class which parses and processes a CSV import, and handles the priming of any required caches."""
 
-    def __init__(self, modelimportformclass):
+    def __init__(self, modelimportformclass) -> None:
         """
         @param modelimportformclass The ImporterModelForm class (which extends a simple ModelForm)
         """

--- a/djangomodelimport/fields.py
+++ b/djangomodelimport/fields.py
@@ -22,12 +22,12 @@ class FlatRelatedField(forms.Field):
     All the magic happens in magic.py in FlatRelatedFieldFormMixin
     """
 
-    def __init__(self, queryset, fields=[], *args, **kwargs):
+    def __init__(self, queryset, fields=None, *args, **kwargs):
         self.queryset = queryset
         # TODO: If lookup key is provided, allow using it to look up value instead of only
         # retrieving it off the object itself.
         self.model = queryset.model
-        self.fields = fields
+        self.fields = fields or {}
         # Required is False, because this check gets passed down to the fields on the related instance.
         return super().__init__(required=False, *args, **kwargs)
 

--- a/djangomodelimport/formclassbuilder.py
+++ b/djangomodelimport/formclassbuilder.py
@@ -83,7 +83,7 @@ class FormClassBuilder:
         # Get the viable headers for the importer class
         form_headers = self.modelimportformclass.get_available_headers()
 
-        # Find all the valid field combinations
+        # Find all the valid header combinations that evaluate to form fields
         valid_headers = _flatten_headers(form_headers)
 
         field_lookup = {}
@@ -99,7 +99,8 @@ class FormClassBuilder:
             for headers in header_group:
                 field_lookup[frozenset(headers)] = field
 
-        # See if each valid field header if in the provided import headers
+        # Check each header combination against the input headers to
+        # see if they evaluate to a field
         valid_present_fields = set()
         for headers, field in field_lookup.items():
             # Flat related fields only need a subset of headers to be a valid field

--- a/djangomodelimport/formclassbuilder.py
+++ b/djangomodelimport/formclassbuilder.py
@@ -32,7 +32,7 @@ class FormClassBuilder:
 
     @cached_property
     def valid_fields(self) -> list[str]:
-        """Using the available headers on the form, prepare a list of valid
+        """Using the provided headers, prepare a list of valid
         fields for this importer. Preserves field ordering as defined by the headers.
         """
 
@@ -44,6 +44,8 @@ class FormClassBuilder:
         valid_present_fields = set()
         for field_name, field_meta in form_field_metadata.items():
             if isinstance(field_meta.field, (FlatRelatedField, JSONField)):
+                # FlatRelatedField: these are a collection of other columns that build a relation on the fly. Always add.
+                # JSONField: these are provided as FIELDNAME__SOME_DATA, so won't match directly. Just let the whole thing through.
                 valid_present_fields.add(field_name)
             else:
                 for source in field_meta.sources:

--- a/djangomodelimport/forms.py
+++ b/djangomodelimport/forms.py
@@ -26,13 +26,13 @@ class ImporterModelForm(
     routines to ensure we are not doing too many queries with our cached fields.
     """
 
-    def __init__(self, data, caches, author=None, *args, **kwargs):
+    def __init__(self, data, caches, author=None, *args, **kwargs) -> None:
         self.caches = caches
         self.author = author
         self._warnings = defaultdict(list)
         super().__init__(data, *args, **kwargs)
 
-    def add_warning(self, field: str, warning: str):
+    def add_warning(self, field: str, warning: str) -> None:
         # Mimic django form behaviour for errors
         if not field:
             field = NON_FIELD_ERRORS
@@ -40,7 +40,7 @@ class ImporterModelForm(
         self._warnings[field].append(warning)
 
     @property
-    def warnings(self):
+    def warnings(self) -> dict[str, list[str]]:
         return dict(self._warnings)
 
     # This improves preview performance but eliminates validation on uniqueness constraints

--- a/djangomodelimport/forms.py
+++ b/djangomodelimport/forms.py
@@ -1,14 +1,18 @@
 from collections import defaultdict
+from functools import partial
 
 from django import forms
 from django.core.exceptions import NON_FIELD_ERRORS
 
+from .fields import FlatRelatedField, SourceFieldSwitcher
 from .magic import (
     CachedChoiceFieldFormMixin,
     FlatRelatedFieldFormMixin,
     JSONFieldFormMixin,
     SourceFieldSwitcherMixin,
 )
+from .utils import HasSource, ImportHeader
+from .widgets import CompositeLookupWidget
 
 
 class ImporterModelForm(
@@ -42,3 +46,106 @@ class ImporterModelForm(
     # This improves preview performance but eliminates validation on uniqueness constraints
     # def validate_unique(self):
     #     pass
+
+    @classmethod
+    def get_available_headers(cls) -> list[ImportHeader]:
+        """Generate a list of available fields for the ImporterClass"""
+        # 1) Evaluate Field type:
+        # - SourceFieldSwitcher: these are a collection of different ways to find a related object.
+        # - FlatRelatedField: these are a collection of other columns that build a relation on the fly.
+
+        # 2) For each field, check its widget to see what headers it reads from
+        # - Anything using NamedSourceWidget or has a "source" attr:
+        #     these lookup columns might not match the form field.
+        # - Anything using CompositeLookupWidget:
+        #     these lookup columns might not always mention the form field target.
+        # - Fields defined as attributes on the importer,
+        #     but not listed as form fields (eg because they're used for postprocessing).
+
+        # Gather help_texts and verbose_names from the model and importer class
+        help_texts = getattr(cls.Meta, "help_texts", {})
+        model_fields = {
+            field.name: {
+                "verbose_name": field.verbose_name,
+                "help_text": field.help_text,
+            }
+            for field in cls.Meta.model._meta.fields
+        }
+
+        for key, value in model_fields.items():
+            if value["help_text"] and key not in help_texts:
+                help_texts[key] = value["help_text"]
+
+        def _get_headers(name, widget, field_instance) -> list[ImportHeader]:
+            """Evaluate the viable headers added by a field widget"""
+            found_headers = []
+            widget_required = True if widget and widget.is_required else False
+
+            match widget:
+                case CompositeLookupWidget(source=sub_fields):
+                    # Collection of options for how a field is defined
+                    for new_sub_headers in map(
+                        partial(
+                            _get_headers,
+                            widget=None,
+                            field_instance=field_instance,
+                        ),
+                        sub_fields,
+                    ):
+                        found_headers.extend(new_sub_headers)
+                case HasSource(source=source):
+                    # Renames the header for a field
+                    # for example the "NamedSourceWidget"
+                    found_headers.append(
+                        ImportHeader(
+                            field=field_instance,
+                            field_name=field_name,
+                            name=source,
+                            help_text=help_texts.get(source, ""),
+                            required=field.required or widget_required,
+                        )
+                    )
+                case _:
+                    # Anything else
+                    found_headers.append(
+                        ImportHeader(
+                            field=field_instance,
+                            field_name=field_name,
+                            name=name,
+                            help_text=help_texts.get(name, ""),
+                            display=model_fields.get(name, {}).get("verbose_name", ""),
+                            required=field.required or widget_required,
+                        )
+                    )
+
+            return found_headers
+
+        import_headers: list[ImportHeader] = []
+
+        for field_name, field in cls.base_fields.items():
+            match field:
+                case SourceFieldSwitcher(fields=switch_fields):
+                    # Containers a collections of ways to assign this field
+                    temp_fields = []
+                    for switch_field in switch_fields:
+                        temp_fields.append(
+                            _get_headers(field_name, switch_field.widget, switch_field)
+                        )
+
+                    new_field = temp_fields[0]
+                    new_field[0].alternatives = temp_fields[1:]
+                    import_headers.extend(new_field)
+                case FlatRelatedField(fields=related_fields):
+                    # Defines a way to create related objects from a set of headers
+                    for new_fields in map(
+                        partial(
+                            _get_headers, widget=field.widget, field_instance=field
+                        ),
+                        related_fields.keys(),
+                    ):
+                        import_headers.extend(new_fields)
+                case _:
+                    fields = _get_headers(field_name, field.widget, field)
+                    import_headers.extend(fields)
+
+        return import_headers

--- a/djangomodelimport/loaders.py
+++ b/djangomodelimport/loaders.py
@@ -1,3 +1,10 @@
+from typing import Iterable, Any, TypeVar
+
+from django.db.models import QuerySet
+
+T = TypeVar("T")
+
+
 class CachedInstanceLoader(dict):
     """A clever cache that queries the database for any missing objects.
 
@@ -5,13 +12,19 @@ class CachedInstanceLoader(dict):
     cached for extra speed.
     """
 
-    def __init__(self, queryset, to_field, *args, **kwargs):
+    def __init__(
+        self,
+        queryset: QuerySet[T],
+        to_field: str | Iterable[str],
+        *args: Any,
+        **kwargs: Any,
+    ):
         self.queryset = queryset
         self.model = queryset.model
         self.to_field = to_field
         self.multifield = isinstance(to_field, list) or isinstance(to_field, tuple)
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: str) -> T:
         # Attempt to get the currently cached value.
         value = super(CachedInstanceLoader, self).__getitem__(item)
 
@@ -21,7 +34,7 @@ class CachedInstanceLoader(dict):
 
         return value
 
-    def __missing__(self, value):
+    def __missing__(self, value: str) -> T:
         if self.multifield:
             params = dict(zip(self.to_field, value))
         else:

--- a/djangomodelimport/utils.py
+++ b/djangomodelimport/utils.py
@@ -13,7 +13,12 @@ class HasSource(Protocol):
 
 @dataclasses.dataclass
 class ImportFieldMetadata:
+    """Describes how a field maps to headers during an import
+
+    For `sources`, they are defined as a list of a group of headers that satisfy the field.
+    """
+
     field: Field
     help_text: str = ""
-    sources: list[tuple[str, ...]] = dataclasses.field(default_factory=list)
+    sources: list[list[tuple[str, str]]] = dataclasses.field(default_factory=list)
     required: bool = False

--- a/djangomodelimport/utils.py
+++ b/djangomodelimport/utils.py
@@ -1,0 +1,20 @@
+import dataclasses
+from typing import runtime_checkable, Protocol, Iterable
+
+from django.forms import Field
+
+
+@runtime_checkable
+class HasSource(Protocol):
+    source: str | Iterable[str]
+
+
+@dataclasses.dataclass
+class ImportHeader:
+    field_name: str
+    field: Field
+    name: str
+    required: bool
+    display: str = ""
+    help_text: str = ""
+    alternatives: list[list["ImportHeader"]] = dataclasses.field(default_factory=list)

--- a/djangomodelimport/utils.py
+++ b/djangomodelimport/utils.py
@@ -12,15 +12,8 @@ class HasSource(Protocol):
 
 
 @dataclasses.dataclass
-class ImportHeader:
-    """Container for passing around header information"""
-
-    field_name: str  # Name of the field on the form
-    field: Field  # Instance of the form field
-    name: str  # The name of the input header
-    required: bool  # Weather the header is required on the form
-    display: str = ""  # Verbose name of the header, Usually pulled from the model
-    help_text: str = ""  # Help text of the header, pulled from the ImporterForm first, then the model
-    alternatives: list[list["ImportHeader"]] = dataclasses.field(
-        default_factory=list
-    )  # A list of alternative headers the same field name
+class ImportFieldMetadata:
+    field: Field
+    help_text: str = ""
+    sources: list[tuple[str, ...]] = dataclasses.field(default_factory=list)
+    required: bool = False

--- a/djangomodelimport/utils.py
+++ b/djangomodelimport/utils.py
@@ -6,15 +6,21 @@ from django.forms import Field
 
 @runtime_checkable
 class HasSource(Protocol):
+    """Matches any object that has a source property"""
+
     source: str | Iterable[str]
 
 
 @dataclasses.dataclass
 class ImportHeader:
-    field_name: str
-    field: Field
-    name: str
-    required: bool
-    display: str = ""
-    help_text: str = ""
-    alternatives: list[list["ImportHeader"]] = dataclasses.field(default_factory=list)
+    """Container for passing around header information"""
+
+    field_name: str  # Name of the field on the form
+    field: Field  # Instance of the form field
+    name: str  # The name of the input header
+    required: bool  # Weather the header is required on the form
+    display: str = ""  # Verbose name of the header, Usually pulled from the model
+    help_text: str = ""  # Help text of the header, pulled from the ImporterForm first, then the model
+    alternatives: list[list["ImportHeader"]] = dataclasses.field(
+        default_factory=list
+    )  # A list of alternative headers the same field name

--- a/poetry.lock
+++ b/poetry.lock
@@ -21,7 +21,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 dev = ["coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "sphinx", "sphinx-notfound-page", "zope.interface"]
 docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
 tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "zope.interface"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six"]
+tests-no-zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six"]
 
 [[package]]
 name = "colorama"
@@ -32,17 +32,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
-name = "Django"
-version = "4.1.3"
-description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
+name = "django"
+version = "3.2.16"
+description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
 category = "main"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.6"
 
 [package.dependencies]
-asgiref = ">=3.5.2,<4"
+asgiref = ">=3.3.2,<4"
+pytz = "*"
 sqlparse = ">=0.2.2"
-tzdata = {version = "*", markers = "sys_platform == \"win32\""}
 
 [package.extras]
 argon2 = ["argon2-cffi (>=19.1.0)"]
@@ -155,6 +155,14 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 six = ">=1.5"
 
 [[package]]
+name = "pytz"
+version = "2022.6"
+description = "World timezone definitions, modern and historical"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -196,18 +204,10 @@ category = "dev"
 optional = false
 python-versions = ">=3.7"
 
-[[package]]
-name = "tzdata"
-version = "2022.6"
-description = "Provider of IANA time zone data"
-category = "main"
-optional = false
-python-versions = ">=2"
-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "f88bfc8ccab779f904a1c60d3833943ee41262fb4c85646f2da71eba282377ae"
+content-hash = "e7ac04fc7072764e32cceff38c6f2e92b6e0537ef9255ab9e62322b1d0be1d85"
 
 [metadata.files]
 asgiref = [
@@ -222,9 +222,9 @@ colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
-Django = [
-    {file = "Django-4.1.3-py3-none-any.whl", hash = "sha256:6b1de6886cae14c7c44d188f580f8ba8da05750f544c80ae5ad43375ab293cd5"},
-    {file = "Django-4.1.3.tar.gz", hash = "sha256:678bbfc8604eb246ed54e2063f0765f13b321a50526bdc8cb1f943eda7fa31f1"},
+django = [
+    {file = "Django-3.2.16-py3-none-any.whl", hash = "sha256:18ba8efa36b69cfcd4b670d0fa187c6fe7506596f0ababe580e16909bcdec121"},
+    {file = "Django-3.2.16.tar.gz", hash = "sha256:3adc285124244724a394fa9b9839cc8cd116faf7d159554c43ecdaa8cdf0b94d"},
 ]
 exceptiongroup = [
     {file = "exceptiongroup-1.0.0-py3-none-any.whl", hash = "sha256:2ac84b496be68464a2da60da518af3785fff8b7ec0d090a581604bc870bdee41"},
@@ -262,6 +262,10 @@ python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
+pytz = [
+    {file = "pytz-2022.6-py2.py3-none-any.whl", hash = "sha256:222439474e9c98fced559f1709d89e6c9cbf8d79c794ff3eb9f8800064291427"},
+    {file = "pytz-2022.6.tar.gz", hash = "sha256:e89512406b793ca39f5971bc999cc538ce125c0e51c27941bef4568b460095e2"},
+]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
@@ -277,8 +281,4 @@ tablib = [
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
-]
-tzdata = [
-    {file = "tzdata-2022.6-py2.py3-none-any.whl", hash = "sha256:04a680bdc5b15750c39c12a448885a51134a27ec9af83667663f0b3a1bf3f342"},
-    {file = "tzdata-2022.6.tar.gz", hash = "sha256:91f11db4503385928c15598c98573e3af07e7229181bee5375bd30f1695ddcae"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -206,8 +206,8 @@ python-versions = ">=3.7"
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.9"
-content-hash = "e7ac04fc7072764e32cceff38c6f2e92b6e0537ef9255ab9e62322b1d0be1d85"
+python-versions = "^3.10"
+content-hash = "62a298650efc8afad5915ed428642ab3f46d071dbccb1411f58e785070c2ce16"
 
 [metadata.files]
 asgiref = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-model-import"
-version = "0.5.1"
+version = "0.6.0"
 description = "A Django library for importing CSVs and other structured data quickly using Django's ModelForm for validation and deserialisation into an instance."
 authors = ["Aidan Lister <aidan@uptickhq.com>"]
 readme = "README.md"
@@ -16,7 +16,7 @@ packages = [
 python = "^3.9"
 python-dateutil = "^2.7.0"
 tablib = "^3.0.0"
-Django = "^4.0.0"
+django = "^3.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 python-dateutil = "^2.7.0"
 tablib = "^3.0.0"
 django = "^3.0.0"


### PR DESCRIPTION
`ImporterModelForm` now provides a method that will present all the available mappable headers

calling `get_field_metadata` will return a dictionary of dataclasses that contain:

- `field` : The form field instance
- `help_text` : The `help_text` of the field, first pulled from `Meta.help_texts`, then the model fields
- `required`: Whether this field is required
- `sources`: A list of different headers that can be supplied to satisfy this field

This method is now used in place to generate the valid fields for the `FormClassBuilder`