### PR TITLE
feat: allow passthrough of kwargs

### DIFF
--- a/djangomodelimport/fields.py
+++ b/djangomodelimport/fields.py
@@ -222,6 +222,6 @@ class JSONField(forms.Field):
 class SourceFieldSwitcher(forms.Field):
     fields = None
 
-    def __init__(self, *fields: Iterable[Field]) -> None:
+    def __init__(self, *fields: Field, **kwargs: Any) -> None:
         self.fields = fields
-        super().__init__()
+        super().__init__(**kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-model-import"
-version = "0.7.1"
+version = "0.7.2"
 description = "A Django library for importing CSVs and other structured data quickly using Django's ModelForm for validation and deserialisation into an instance."
 authors = ["Aidan Lister <aidan@uptickhq.com>"]
 readme = "README.md"


### PR DESCRIPTION
Allow the passthrough of `kwargs` so we can specify when a SourceFieldSwticher isn't a required field

---

also fixed the typing of fields as `*args` already captures that the result is Iterable

PyCharm has been complaining at me for ages about this but it only just clicked this is why.