### PR TITLE
TW-3033 fix: add missing super call

### DIFF
--- a/djangomodelimport/__init__.py
+++ b/djangomodelimport/__init__.py
@@ -7,4 +7,4 @@ from .parsers import (
 )  # noqa
 from .resultset import ImportResultRow, ImportResultSet  # noqa
 
-__version__ = "0.7.1"
+__version__ = "0.7.3"

--- a/djangomodelimport/magic.py
+++ b/djangomodelimport/magic.py
@@ -115,10 +115,10 @@ class CachedChoiceFieldFormMixin:
         """We need to exclude any CachedChoiceFields from validation, as this
         causes a m * n queries where m is the number of relations, n is rows.
         """
-        exclude = []
+        exclude = super()._get_validation_exclusions()
         for field, fieldinstance in self.fields.items():
             if isinstance(fieldinstance, CachedChoiceField):
-                exclude.append(field)
+                exclude.add(field)
         return exclude
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-model-import"
-version = "0.7.2"
+version = "0.7.3"
 description = "A Django library for importing CSVs and other structured data quickly using Django's ModelForm for validation and deserialisation into an instance."
 authors = ["Aidan Lister <aidan@uptickhq.com>"]
 readme = "README.md"


### PR DESCRIPTION
Added a missing super call to the CachedChoiceForm mixin.

Was causing fields not in the import to be incorrectly validated.