### PR TITLE
fix(parsers): disallow empty first line and empty csvs

### DIFF
--- a/djangomodelimport/parsers.py
+++ b/djangomodelimport/parsers.py
@@ -46,6 +46,9 @@ class TablibCSVImportParser(TablibBaseImportParser):
         dataset = self.dataset_class()
         dataset.csv = data
 
+        if not dataset.headers:
+            return ([], [])
+
         header_map = self.get_soft_headings()
 
         # Make all our headings lowercase and sub in soft headings


### PR DESCRIPTION
## Context:
A user can input an empty csv, or have an empty first line, and djangomodelimport will die when trying to enumerate through the headers.  This is causing an error with little to no useful information being sent back to the user.

## Logic:
This PR will make the CSV parser return 2 empty lists if headers is empty.  We don't support headerless CSVs, and neither does tablib, so if there are no headers, we can early return.  
I thought of throwing an exception, however all current implementations of this parser would call something like `headers, rows = parser.parse()`.  Throwing an exception here, then means that the calls will have to be changed.  But I am happy to throw out some sort of ValueError instead

## Caveat:
This will throw out an error on blank CSVs, but also any CSVs that have leading whitespace lines.  If we really want to allow users to have leading blank lines, then we can do some sort of sanitisation before we parse it, but otherwise we currently don't allow it, so I see no reason to add in that functionality right now.